### PR TITLE
Fix Syntax error

### DIFF
--- a/app/api/getHost.ts
+++ b/app/api/getHost.ts
@@ -1,7 +1,7 @@
 import EnvChecker from "../helpers/envChecker";
 
 const PROD_API_HOST = "https://api.scinapse.io"; // This API HOST is used for a REAL service.
-const DEV_API_HOST = "https://author.dev-api.scinapse.io"; // This API Host is used for DEV, Stage service.
+const DEV_API_HOST = "https://dev-api.scinapse.io"; // This API Host is used for DEV, Stage service.
 
 export default function getAPIHost() {
   if (EnvChecker.isLocal() || EnvChecker.isLocalServer()) {

--- a/app/components/authorShowHeader/index.tsx
+++ b/app/components/authorShowHeader/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import Truncate from "react-truncate";
-import Tooltip from "@material-ui/core/Tooltip";
+import MuiTooltip from "@material-ui/core/Tooltip";
 import { withStyles } from "../../helpers/withStylesHelper";
 import { Author } from "../../model/author/author";
 import Icon from "../../icons";
@@ -47,7 +47,7 @@ class AuthorShowHeader extends React.PureComponent<AuthorShowHeaderProps, Author
                 <div>
                   <span className={styles.username}>{author.name}</span>{" "}
                   {author.isLayered ? (
-                    <Tooltip
+                    <MuiTooltip
                       classes={{ tooltip: styles.verificationTooltip }}
                       title="Verification Author"
                       placement="right"
@@ -55,7 +55,7 @@ class AuthorShowHeader extends React.PureComponent<AuthorShowHeaderProps, Author
                       <div className={styles.contactIconWrapper}>
                         <Icon icon="OCCUPIED" className={styles.occupiedIcon} />
                       </div>
-                    </Tooltip>
+                    </MuiTooltip>
                   ) : null}
                 </div>
                 <div className={styles.affiliation}>

--- a/app/components/common/coAuthor/index.tsx
+++ b/app/components/common/coAuthor/index.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
-import Tooltip from "@material-ui/core/Tooltip";
+import MuiTooltip from "@material-ui/core/Tooltip";
 import { Author } from "../../../model/author/author";
 import { trackEvent } from "../../../helpers/handleGA";
 import HIndexBox from "../hIndexBox";
@@ -30,11 +30,11 @@ const CoAuthor = (props: CoAuthorProps) => {
         <div className={styles.coAuthorName}>
           {author.name}{" "}
           {author.isLayered ? (
-            <Tooltip classes={{ tooltip: styles.verificationTooltip }} title="Verification Author" placement="right">
+            <MuiTooltip classes={{ tooltip: styles.verificationTooltip }} title="Verification Author" placement="right">
               <div className={styles.contactIconWrapper}>
                 <Icon icon="OCCUPIED" className={styles.occupiedIcon} />
               </div>
-            </Tooltip>
+            </MuiTooltip>
           ) : null}
         </div>
         <div className={styles.hIndexWrapper}>

--- a/app/components/common/paperItem/authors.tsx
+++ b/app/components/common/paperItem/authors.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
 import * as classNames from "classnames";
-import Tooltip from "@material-ui/core/Tooltip";
+import Tooltip from "../tooltip/tooltip";
 import { PaperAuthor } from "../../../model/author";
 import { withStyles } from "../../../helpers/withStylesHelper";
 import { trackEvent } from "../../../helpers/handleGA";

--- a/app/components/paperShow/components/author.tsx
+++ b/app/components/paperShow/components/author.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { Link } from "react-router-dom";
-import Tooltip from "@material-ui/core/Tooltip";
+import MuiTooltip from "@material-ui/core/Tooltip";
 import { withStyles } from "../../../helpers/withStylesHelper";
 import HIndexBox from "../../common/hIndexBox";
 import { PaperAuthor } from "../../../model/author";
@@ -36,11 +36,11 @@ const PostAuthor = ({ author }: PostAuthorProps) => {
       <span className={styles.name}>
         {author.name}{" "}
         {author.is_layered ? (
-          <Tooltip classes={{ tooltip: styles.verificationTooltip }} title="Verification Author" placement="right">
+          <MuiTooltip classes={{ tooltip: styles.verificationTooltip }} title="Verification Author" placement="right">
             <div className={styles.contactIconWrapper}>
               <Icon icon="OCCUPIED" className={styles.occupiedIcon} />
             </div>
-          </Tooltip>
+          </MuiTooltip>
         ) : null}
       </span>
       {getOrganization(author.organization)}


### PR DESCRIPTION
The cause of this problem is that the Tooltip already exists (it is used for hindex). The name of the tooltip imported from material ui has been changed to MuiTooltip.