### PR TITLE
Add the logic that forcely set referrer to the current origin

### DIFF
--- a/app/components/auth/signIn/actions.tsx
+++ b/app/components/auth/signIn/actions.tsx
@@ -1,4 +1,5 @@
 import { Dispatch } from "redux";
+import * as ReactGA from "react-ga";
 import { AxiosError } from "axios";
 import AuthAPI from "../../../api/auth";
 import { ACTION_TYPES } from "../../../actions/actionTypes";
@@ -114,7 +115,9 @@ export async function signInWithSocial(vendor: OAUTH_VENDOR) {
       vendor,
       redirectUri,
     });
+
     if (!EnvChecker.isOnServer()) {
+      ReactGA.set({ referrer: EnvChecker.getOrigin() });
       window.location.replace(authorizeUriData.uri);
     }
   } catch (_err) {

--- a/app/components/auth/signUp/actions.tsx
+++ b/app/components/auth/signUp/actions.tsx
@@ -1,4 +1,5 @@
 import { Dispatch } from "redux";
+import * as ReactGA from "react-ga";
 import AuthAPI from "../../../api/auth";
 import { PostExchangeResult, OAUTH_VENDOR, GetAuthorizeUriResult } from "../../../api/types/auth";
 import { ACTION_TYPES } from "../../../actions/actionTypes";
@@ -386,6 +387,7 @@ export function signUpWithSocial(currentStep: SIGN_UP_STEP, vendor: OAUTH_VENDOR
           trackEvent({ category: "sign_up", action: "try_to_sign_up_step_1", label: `with_${vendor}` });
 
           if (!EnvChecker.isOnServer()) {
+            ReactGA.set({ referrer: origin });
             window.location.replace(authorizeUriData.uri);
           }
         } catch (err) {


### PR DESCRIPTION
`Task`
https://www.notion.so/pluto/GA-referral-8fbc6b5bdee24da3ac2c5c371802f5c0

`Ref`
https://medium.com/fatllama-engineering/excluding-facebook-and-google-social-sign-in-from-your-referrals-with-google-analytics-ff81588e519