### PR TITLE
Fixed DataFormalConversion.MalformedData

### DIFF
--- a/app/components/filterContainer/trackSelectFilter.tsx
+++ b/app/components/filterContainer/trackSelectFilter.tsx
@@ -9,6 +9,6 @@ export function trackSelectFilter(actionType: FILTER_BOX_TYPE, actionValue: stri
     actionType: "fire",
     actionArea: "filter",
     actionTag: actionType,
-    actionLabel: actionValue,
+    actionLabel: String(actionValue),
   });
 }

--- a/app/components/locationListener/index.tsx
+++ b/app/components/locationListener/index.tsx
@@ -126,7 +126,7 @@ class LocationListener extends React.PureComponent<LocationListenerProps> {
         actionType: "view",
         actionArea: null,
         actionTag: "pageView",
-        actionLabel: !isNaN(id) ? id : null,
+        actionLabel: !isNaN(id) ? String(id) : null,
       });
     }
   }

--- a/app/helpers/actionTicketManager/actionTicket.tsx
+++ b/app/helpers/actionTicketManager/actionTicket.tsx
@@ -8,7 +8,7 @@ export interface ActionTicketParams {
   actionArea: Scinapse.ActionTicket.ActionArea | Scinapse.ActionTicket.PageType | null;
   actionType: "fire" | "view";
   actionTag: Scinapse.ActionTicket.ActionTagType;
-  actionLabel: string | number | null;
+  actionLabel: string | null;
 }
 
 export interface FinalActionTicket extends ActionTicketParams {
@@ -31,7 +31,7 @@ export default class ActionTicket {
   private actionTag: Scinapse.ActionTicket.ActionTagType;
   private actionArea: Scinapse.ActionTicket.ActionArea | Scinapse.ActionTicket.PageType | null;
   private pageType: Scinapse.ActionTicket.PageType;
-  private actionLabel: string | number | null;
+  private actionLabel: string | null;
   private _errorCount = 0;
 
   public constructor(params: ActionTicketParams) {


### PR DESCRIPTION
AWS Kinesis Firehose transformation procedure raises the DataFormalConversion.MalformedData Error when a string field on AWS glue table contains integer exceeds 32-bit integer range.