### PR TITLE
Remove semantic search ab test

### DIFF
--- a/app/api/search.ts
+++ b/app/api/search.ts
@@ -15,7 +15,6 @@ export interface BaseSearchParams {
   sort: string;
   page?: number;
   cancelToken?: CancelToken;
-  semantic?: boolean;
 }
 
 export interface PaperSearchParams extends BaseSearchParams {
@@ -59,14 +58,13 @@ export interface AuthorSearchResult extends PaginationResponseV2<Author[]> {
 }
 
 class SearchAPI extends PlutoAxios {
-  public async search({ query, sort, filter, page = 0, cancelToken, semantic }: PaperSearchParams) {
+  public async search({ query, sort, filter, page = 0, cancelToken }: PaperSearchParams) {
     const res = await this.get('/search', {
       params: {
         q: query,
         sort,
         filter,
         page,
-        semantic,
       },
       cancelToken,
     });

--- a/app/api/types/paper.ts
+++ b/app/api/types/paper.ts
@@ -8,7 +8,6 @@ export interface SearchPapersParams {
   filter: string;
   size?: number;
   cancelToken?: CancelToken;
-  semantic?: boolean;
 }
 
 export interface GetRefOrCitedPapersParams {

--- a/app/components/articleSearch/index.tsx
+++ b/app/components/articleSearch/index.tsx
@@ -31,8 +31,6 @@ import FilterContainer from '../../containers/filterContainer';
 import ScinapseFooter from '../layouts/scinapseFooter';
 import ArticleSpinner from '../common/spinner/articleSpinner';
 import GuruBox from './components/guruBox';
-import { getUserGroupName } from '../../helpers/abTestHelper';
-import { SEMANTIC_SEARCH_TEST } from '../../constants/abTestGlobalValue';
 import { changeSearchQuery } from '../../actions/searchQuery';
 import SafeURIStringHandler from '../../helpers/safeURIStringHandler';
 const styles = require('./articleSearch.scss');
@@ -203,8 +201,6 @@ const SearchContainer: React.FC<Props> = props => {
     () => {
       if (currentUserState.isLoggingIn) return;
 
-      const doSemanticSearch = getUserGroupName(SEMANTIC_SEARCH_TEST) === 'semantic';
-
       const currentQueryParams = parse(location.search, { ignoreQueryPrefix: true });
       changeSearchQuery(SafeURIStringHandler.decode(currentQueryParams.query || ''));
       setQueryParams(currentQueryParams);
@@ -212,9 +208,6 @@ const SearchContainer: React.FC<Props> = props => {
       // set params
       const params = SearchQueryManager.makeSearchQueryFromParamsObject(currentQueryParams);
       params.cancelToken = cancelToken.current.token;
-      if (doSemanticSearch) {
-        params.semantic = true;
-      }
 
       searchPapers(params).then(() => {
         restoreScroll(location.key);

--- a/app/constants/abTest.tsx
+++ b/app/constants/abTest.tsx
@@ -3,7 +3,6 @@ import {
   searchItemImprovement,
   homeImprovement,
   guruAtSearch,
-  semanticSearch,
   knowledgeBasedRecommend,
 } from './abTestObject';
 
@@ -24,7 +23,6 @@ export type ABTest =
   | 'searchItemImprovement'
   | 'guruAtSearch'
   | 'homeImprovement'
-  | 'semanticSearch'
   | 'knowledgeBasedRecommend';
 
 export const SIGN_UP_CONVERSION_KEY = 'b_exp';
@@ -50,7 +48,6 @@ export const LIVE_TESTS: Test[] = [
   searchItemImprovement,
   homeImprovement,
   guruAtSearch,
-  semanticSearch,
   knowledgeBasedRecommend,
 ];
 

--- a/app/constants/abTestGlobalValue.tsx
+++ b/app/constants/abTestGlobalValue.tsx
@@ -4,5 +4,4 @@ export const SIGN_BANNER_AT_PAPER_SHOW_TEST: ABTest = 'signBannerAtPaperShow';
 export const SEARCH_ITEM_IMPROVEMENT_TEST: ABTest = 'searchItemImprovement';
 export const HOME_IMPROVEMENT_TEST: ABTest = 'homeImprovement';
 export const GURU_AT_SEARCH_TEST: ABTest = 'guruAtSearch';
-export const SEMANTIC_SEARCH_TEST: ABTest = 'semanticSearch';
 export const KNOWLEDGE_BASED_RECOMMEND_TEST: ABTest = 'knowledgeBasedRecommend';

--- a/app/constants/abTestObject.tsx
+++ b/app/constants/abTestObject.tsx
@@ -4,7 +4,6 @@ import {
   SEARCH_ITEM_IMPROVEMENT_TEST,
   HOME_IMPROVEMENT_TEST,
   GURU_AT_SEARCH_TEST,
-  SEMANTIC_SEARCH_TEST,
   KNOWLEDGE_BASED_RECOMMEND_TEST,
 } from './abTestGlobalValue';
 
@@ -32,11 +31,6 @@ export const homeImprovement: Test = {
 export const guruAtSearch: Test = {
   name: GURU_AT_SEARCH_TEST,
   userGroup: [{ groupName: 'control', weight: 1 }, { groupName: 'guru', weight: 4 }],
-};
-
-export const semanticSearch: Test = {
-  name: SEMANTIC_SEARCH_TEST,
-  userGroup: [{ groupName: 'control', weight: 1 }, { groupName: 'semantic', weight: 1 }],
 };
 
 export const knowledgeBasedRecommend: Test = {


### PR DESCRIPTION
apply `semantic`

However, all actions associated with that experiment will be modified to run on the `backend`.

Therefore, we performed the operation of erasing the front-end source code. 